### PR TITLE
github recently changed default branch from master to main

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@
 .. _gitter: https://gitter.im/sktime/community
 
 .. |binder| image:: https://mybinder.org/badge_logo.svg
-.. _Binder: https://mybinder.org/v2/gh/sktime/sktime-tutorial-pydata-amsterdam-2020/master?filepath=notebooks
+.. _Binder: https://mybinder.org/v2/gh/sktime/sktime-tutorial-pydata-amsterdam-2020/main?filepath=notebooks
 
 
 This tutorial was written for sktime version 0.4.2, for more up-to-date notebooks visit sktime's `online documentation <https://www.sktime.org/en/latest/how_to_get_started.html>`__.


### PR DESCRIPTION
While I was opening binder link it shows error due to Github url and the solution was to change master to main in link. 

![image](https://user-images.githubusercontent.com/29429768/121560443-5c101000-c9cc-11eb-9117-62d9af8999c0.png)
 